### PR TITLE
Use goregen to generate usage samples using actual keywords.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -38,6 +38,10 @@
 			"Rev": "7c2b1e5640dcf2631213ca962d892bffa1e08860"
 		},
 		{
+			"ImportPath": "github.com/zach-klippenstein/goregen",
+			"Rev": "a55a25e1740eb60f4c82c74c5e27b976839f7531"
+		},
+		{
 			"ImportPath": "golang.org/x/net/context",
 			"Rev": "db8e4de5b2d6653f66aea53094624468caad15d2"
 		},

--- a/cmd/memebot/main.go
+++ b/cmd/memebot/main.go
@@ -166,7 +166,12 @@ func startBot(memepository Memepository) {
 		log.Fatal("Slack token not found. Set ", SlackTokenVar)
 	}
 
-	parser, err := NewRegexpKeywordParser(*KeywordPattern)
+	// Load the set of keywords for the sample generator.
+	memeIndex, err := memepository.Load()
+	if err != nil {
+		log.Fatalln("error loading keywords:", err)
+	}
+	parser, err := NewRegexpKeywordParser(*KeywordPattern, memeIndex.Keywords())
 	if err != nil {
 		log.Fatalf("error compiling keyword pattern '%s': %s", *KeywordPattern, err)
 	}

--- a/vendor/github.com/zach-klippenstein/goregen/.gitignore
+++ b/vendor/github.com/zach-klippenstein/goregen/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# IntelliJ
+*.iml
+.idea/

--- a/vendor/github.com/zach-klippenstein/goregen/.travis.yml
+++ b/vendor/github.com/zach-klippenstein/goregen/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - 1.5.1
+  - tip
+
+sudo: false

--- a/vendor/github.com/zach-klippenstein/goregen/LICENSE.txt
+++ b/vendor/github.com/zach-klippenstein/goregen/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/zach-klippenstein/goregen/README.md
+++ b/vendor/github.com/zach-klippenstein/goregen/README.md
@@ -1,0 +1,7 @@
+#goregen [![GoDoc](https://godoc.org/github.com/zach-klippenstein/goregen?status.svg)](https://godoc.org/github.com/zach-klippenstein/goregen) [![Build Status](https://travis-ci.org/zach-klippenstein/goregen.svg?branch=master)](https://travis-ci.org/zach-klippenstein/goregen)
+
+A Golang library for generating random strings from regular expressions.
+
+Checkout https://goregen-demo.herokuapp.com for a live demo.
+
+See the [godoc](https://godoc.org/github.com/zach-klippenstein/goregen) for examples.

--- a/vendor/github.com/zach-klippenstein/goregen/char_class.go
+++ b/vendor/github.com/zach-klippenstein/goregen/char_class.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"fmt"
+)
+
+// CharClass represents a regular expression character class as a list of ranges.
+// The runes contained in the class can be accessed by index.
+type tCharClass struct {
+	Ranges    []tCharClassRange
+	TotalSize int32
+}
+
+// CharClassRange represents a single range of characters in a character class.
+type tCharClassRange struct {
+	Start rune
+	Size  int32
+}
+
+// NewCharClass creates a character class with a single range.
+func newCharClass(start rune, end rune) *tCharClass {
+	charRange := newCharClassRange(start, end)
+	return &tCharClass{
+		Ranges:    []tCharClassRange{charRange},
+		TotalSize: charRange.Size,
+	}
+}
+
+/*
+ParseCharClass parses a character class as represented by syntax.Parse into a slice of CharClassRange structs.
+
+Char classes are encoded as pairs of runes representing ranges:
+[0-9] = 09, [a0] = aa00 (2 1-len ranges).
+
+e.g.
+
+"[a0-9]" -> "aa09" -> a, 0-9
+
+"[^a-z]" -> "…" -> 0-(a-1), (z+1)-(max rune)
+*/
+func parseCharClass(runes []rune) *tCharClass {
+	var totalSize int32
+	numRanges := len(runes) / 2
+	ranges := make([]tCharClassRange, numRanges, numRanges)
+
+	for i := 0; i < numRanges; i++ {
+		start := runes[i*2]
+		end := runes[i*2+1]
+
+		// indicates a negative class
+		if start == 0 {
+			// doesn't make sense to generate null bytes, so all ranges must start at
+			// no less than 1.
+			start = 1
+		}
+
+		r := newCharClassRange(start, end)
+
+		ranges[i] = r
+		totalSize += r.Size
+	}
+
+	return &tCharClass{ranges, totalSize}
+}
+
+// GetRuneAt gets a rune from CharClass as a contiguous array of runes.
+func (class *tCharClass) GetRuneAt(i int32) rune {
+	for _, r := range class.Ranges {
+		if i < r.Size {
+			return r.Start + rune(i)
+		}
+		i -= r.Size
+	}
+	panic("index out of bounds")
+}
+
+func (class *tCharClass) String() string {
+	return fmt.Sprintf("%s", class.Ranges)
+}
+
+func newCharClassRange(start rune, end rune) tCharClassRange {
+	if start < 1 {
+		panic("char class range cannot contain runes less than 1")
+	}
+
+	size := end - start + 1
+
+	if size < 1 {
+		panic("char class range size must be at least 1")
+	}
+
+	return tCharClassRange{
+		Start: start,
+		Size:  size,
+	}
+}
+
+func (r tCharClassRange) String() string {
+	if r.Size == 1 {
+		return fmt.Sprintf("%s:1", runesToString(r.Start))
+	}
+	return fmt.Sprintf("%s-%s:%d", runesToString(r.Start), runesToString(r.Start+rune(r.Size-1)), r.Size)
+
+}

--- a/vendor/github.com/zach-klippenstein/goregen/generator_error.go
+++ b/vendor/github.com/zach-klippenstein/goregen/generator_error.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"fmt"
+)
+
+// Error returned by a generatorFactory if the AST is invalid.
+type tGeneratorError struct {
+	ErrorStr string
+	Cause    error
+}
+
+func generatorError(cause error, format string, args ...interface{}) error {
+	return &tGeneratorError{fmt.Sprintf(format, args...), cause}
+}
+
+func (err *tGeneratorError) Error() string {
+	if err.Cause != nil {
+		return fmt.Sprintf("%s\ncaused by %s", err.ErrorStr, err.Cause.Error())
+	}
+	return err.ErrorStr
+}

--- a/vendor/github.com/zach-klippenstein/goregen/generator_error_test.go
+++ b/vendor/github.com/zach-klippenstein/goregen/generator_error_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGeneratorError(t *testing.T) {
+	Convey("GeneratorError", t, func() {
+
+		Convey("Handles nil cause", func() {
+			err := generatorError(nil, "msg")
+			So(err.Error(), ShouldEqual, "msg")
+		})
+
+		Convey("Formats", func() {
+			err := generatorError(errors.New("cause"), "msg %s", "arg")
+			So(err.Error(), ShouldEqual, "msg arg\ncaused by cause")
+		})
+	})
+}

--- a/vendor/github.com/zach-klippenstein/goregen/internal_generator.go
+++ b/vendor/github.com/zach-klippenstein/goregen/internal_generator.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"regexp/syntax"
+)
+
+// generatorFactory is a function that creates a random string generator from a regular expression AST.
+type generatorFactory func(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error)
+
+// Must be initialized in init() to avoid "initialization loop" compile error.
+var generatorFactories map[syntax.Op]generatorFactory
+
+const noBound = -1
+
+func init() {
+	generatorFactories = map[syntax.Op]generatorFactory{
+		syntax.OpEmptyMatch:     opEmptyMatch,
+		syntax.OpLiteral:        opLiteral,
+		syntax.OpAnyCharNotNL:   opAnyCharNotNl,
+		syntax.OpAnyChar:        opAnyChar,
+		syntax.OpQuest:          opQuest,
+		syntax.OpStar:           opStar,
+		syntax.OpPlus:           opPlus,
+		syntax.OpRepeat:         opRepeat,
+		syntax.OpCharClass:      opCharClass,
+		syntax.OpConcat:         opConcat,
+		syntax.OpAlternate:      opAlternate,
+		syntax.OpCapture:        opCapture,
+		syntax.OpBeginLine:      noop,
+		syntax.OpEndLine:        noop,
+		syntax.OpBeginText:      noop,
+		syntax.OpEndText:        noop,
+		syntax.OpWordBoundary:   noop,
+		syntax.OpNoWordBoundary: noop,
+	}
+}
+
+type internalGenerator struct {
+	Name         string
+	GenerateFunc func() string
+}
+
+func (gen *internalGenerator) Generate() string {
+	return gen.GenerateFunc()
+}
+
+func (gen *internalGenerator) String() string {
+	return gen.Name
+}
+
+// Create a new generator for each expression in regexps.
+func newGenerators(regexps []*syntax.Regexp, args *GeneratorArgs) ([]*internalGenerator, error) {
+	generators := make([]*internalGenerator, len(regexps), len(regexps))
+	var err error
+
+	// create a generator for each alternate pattern
+	for i, subR := range regexps {
+		generators[i], err = newGenerator(subR, args)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return generators, nil
+}
+
+// Create a new generator for r.
+func newGenerator(regexp *syntax.Regexp, args *GeneratorArgs) (generator *internalGenerator, err error) {
+	simplified := regexp.Simplify()
+
+	factory, ok := generatorFactories[simplified.Op]
+	if ok {
+		return factory(simplified, args)
+	}
+
+	return nil, fmt.Errorf("invalid generator pattern: /%s/ as /%s/\n%s",
+		regexp, simplified, inspectRegexpToString(simplified))
+}
+
+// Generator that does nothing.
+func noop(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	return &internalGenerator{regexp.String(), func() string {
+		return ""
+	}}, nil
+}
+
+func opEmptyMatch(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpEmptyMatch)
+	return &internalGenerator{regexp.String(), func() string {
+		return ""
+	}}, nil
+}
+
+func opLiteral(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpLiteral)
+	return &internalGenerator{regexp.String(), func() string {
+		return runesToString(regexp.Rune...)
+	}}, nil
+}
+
+func opAnyChar(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpAnyChar)
+	return &internalGenerator{regexp.String(), func() string {
+		return runesToString(rune(args.rng.Int31()))
+	}}, nil
+}
+
+func opAnyCharNotNl(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpAnyCharNotNL)
+	charClass := newCharClass(1, rune(math.MaxInt32))
+	return createCharClassGenerator(regexp.String(), charClass, args)
+}
+
+func opQuest(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpQuest)
+	return createRepeatingGenerator(regexp, args, 0, 1)
+}
+
+func opStar(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpStar)
+	return createRepeatingGenerator(regexp, args, noBound, noBound)
+}
+
+func opPlus(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpPlus)
+	return createRepeatingGenerator(regexp, args, 1, noBound)
+}
+
+func opRepeat(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpRepeat)
+	return createRepeatingGenerator(regexp, args, regexp.Min, regexp.Max)
+}
+
+// Handles syntax.ClassNL because the parser uses that flag to generate character
+// classes that respect it.
+func opCharClass(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpCharClass)
+	charClass := parseCharClass(regexp.Rune)
+	return createCharClassGenerator(regexp.String(), charClass, args)
+}
+
+func opConcat(regexp *syntax.Regexp, genArgs *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpConcat)
+
+	generators, err := newGenerators(regexp.Sub, genArgs)
+	if err != nil {
+		return nil, generatorError(err, "error creating generators for concat pattern /%s/", regexp)
+	}
+
+	return &internalGenerator{regexp.String(), func() string {
+		var result bytes.Buffer
+		for _, generator := range generators {
+			result.WriteString(generator.Generate())
+		}
+		return result.String()
+	}}, nil
+}
+
+func opAlternate(regexp *syntax.Regexp, genArgs *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpAlternate)
+
+	generators, err := newGenerators(regexp.Sub, genArgs)
+	if err != nil {
+		return nil, generatorError(err, "error creating generators for alternate pattern /%s/", regexp)
+	}
+
+	numGens := len(generators)
+
+	return &internalGenerator{regexp.String(), func() string {
+		i := genArgs.rng.Intn(numGens)
+		generator := generators[i]
+		return generator.Generate()
+	}}, nil
+}
+
+func opCapture(regexp *syntax.Regexp, args *GeneratorArgs) (*internalGenerator, error) {
+	enforceOp(regexp, syntax.OpCapture)
+
+	if err := enforceSingleSub(regexp); err != nil {
+		return nil, err
+	}
+
+	groupRegexp := regexp.Sub[0]
+	generator, err := newGenerator(groupRegexp, args)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group indices are 0-based, but index 0 is the whole expression.
+	index := regexp.Cap - 1
+
+	return &internalGenerator{regexp.String(), func() string {
+		return args.CaptureGroupHandler(index, regexp.Name, groupRegexp, generator, args)
+	}}, nil
+}
+
+func defaultCaptureGroupHandler(index int, name string, group *syntax.Regexp, generator Generator, args *GeneratorArgs) string {
+	return generator.Generate()
+}
+
+// Panic if r.Op != op.
+func enforceOp(r *syntax.Regexp, op syntax.Op) {
+	if r.Op != op {
+		panic(fmt.Sprintf("invalid Op: expected %s, was %s", opToString(op), opToString(r.Op)))
+	}
+}
+
+// Return an error if r has 0 or more than 1 sub-expression.
+func enforceSingleSub(regexp *syntax.Regexp) error {
+	if len(regexp.Sub) != 1 {
+		return generatorError(nil,
+			"%s expected 1 sub-expression, but got %d: %s", opToString(regexp.Op), len(regexp.Sub), regexp)
+	}
+	return nil
+}
+
+func createCharClassGenerator(name string, charClass *tCharClass, args *GeneratorArgs) (*internalGenerator, error) {
+	return &internalGenerator{name, func() string {
+		i := args.rng.Int31n(charClass.TotalSize)
+		r := charClass.GetRuneAt(i)
+		return runesToString(r)
+	}}, nil
+}
+
+// Returns a generator that will run the generator for r's sub-expression [min, max] times.
+func createRepeatingGenerator(regexp *syntax.Regexp, genArgs *GeneratorArgs, min, max int) (*internalGenerator, error) {
+	if err := enforceSingleSub(regexp); err != nil {
+		return nil, err
+	}
+
+	generator, err := newGenerator(regexp.Sub[0], genArgs)
+	if err != nil {
+		return nil, generatorError(err, "failed to create generator for subexpression: /%s/", regexp)
+	}
+
+	if min == noBound {
+		min = int(genArgs.MinUnboundedRepeatCount)
+	}
+	if max == noBound {
+		max = int(genArgs.MaxUnboundedRepeatCount)
+	}
+
+	return &internalGenerator{regexp.String(), func() string {
+		n := min + genArgs.rng.Intn(max-min+1)
+
+		var result bytes.Buffer
+		for i := 0; i < n; i++ {
+			result.WriteString(generator.Generate())
+		}
+		return result.String()
+	}}, nil
+}

--- a/vendor/github.com/zach-klippenstein/goregen/regen.go
+++ b/vendor/github.com/zach-klippenstein/goregen/regen.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package regen is a library for generating random strings from regular expressions.
+The generated strings will match the expressions they were generated from. Similar
+to Ruby's randexp library.
+
+E.g.
+	regen.Generate("[a-z0-9]{1,64}")
+will return a lowercase alphanumeric string
+between 1 and 64 characters long.
+
+Expressions are parsed using the Go standard library's parser: http://golang.org/pkg/regexp/syntax/.
+
+Constraints
+
+"." will generate any character, not necessarily a printable one.
+
+"x{0,}", "x*", and "x+" will generate a random number of x's up to an arbitrary limit.
+If you care about the maximum number, specify it explicitly in the expression,
+e.g. "x{0,256}".
+
+Flags
+
+Flags can be passed to the parser by setting them in the GeneratorArgs struct.
+Newline flags are respected, and newlines won't be generated unless the appropriate flags for
+matching them are set.
+
+E.g.
+Generate(".|[^a]") will never generate newlines. To generate newlines, create a generator and pass
+the flag syntax.MatchNL.
+
+The Perl character class flag is supported, and required if the pattern contains them.
+
+Unicode groups are not supported at this time. Support may be added in the future.
+
+Concurrent Use
+
+A generator can safely be used from multiple goroutines without locking.
+
+A large bottleneck with running generators concurrently is actually the entropy source. Sources returned from
+rand.NewSource() are slow to seed, and not safe for concurrent use. Instead, the source passed in GeneratorArgs
+is used to seed an XorShift64 source (algorithm from the paper at http://vigna.di.unimi.it/ftp/papers/xorshift.pdf).
+This source only uses a single variable internally, and is much faster to seed than the default source. One
+source is created per call to NewGenerator. If no source is passed in, the default source is used to seed.
+
+The source is not locked and does not use atomic operations, so there is a chance that multiple goroutines using
+the same source may get the same output. While obviously not cryptographically secure, I think the simplicity and performance
+benefit outweighs the risk of collisions. If you really care about preventing this, the solution is simple: don't
+call a single Generator from multiple goroutines.
+
+Benchmarks
+
+Benchmarks are included for creating and running generators for limited-length,
+complex regexes, and simple, highly-repetitive regexes.
+
+	go test -bench .
+
+The complex benchmarks generate fake HTTP messages with the following regex:
+	POST (/[-a-zA-Z0-9_.]{3,12}){3,6}
+	Content-Length: [0-9]{2,3}
+	X-Auth-Token: [a-zA-Z0-9+/]{64}
+
+	([A-Za-z0-9+/]{64}
+	){3,15}[A-Za-z0-9+/]{60}([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)
+
+The repetitive benchmarks use the regex
+	a{999}
+
+See regen_benchmarks_test.go for more information.
+
+On my mid-2014 MacBook Pro (2.6GHz Intel Core i5, 8GB 1600MHz DDR3),
+the results of running the benchmarks with minimal load are:
+	BenchmarkComplexCreation-4                       200	   8322160 ns/op
+	BenchmarkComplexGeneration-4                   10000	    153625 ns/op
+	BenchmarkLargeRepeatCreateSerial-4  	        3000	    411772 ns/op
+	BenchmarkLargeRepeatGenerateSerial-4	        5000	    291416 ns/op
+*/
+package regen
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp/syntax"
+)
+
+// DefaultMaxUnboundedRepeatCount is default value for MaxUnboundedRepeatCount.
+const DefaultMaxUnboundedRepeatCount = 4096
+
+// CaptureGroupHandler is a function that is called for each capture group in a regular expression.
+// index and name are the index and name of the group. If unnamed, name is empty. The first capture group has index 0
+// (not 1, as when matching).
+// group is the regular expression within the group (e.g. for `(\w+)`, group would be `\w+`).
+// generator is the generator for group.
+// args is the args used to create the generator calling this function.
+type CaptureGroupHandler func(index int, name string, group *syntax.Regexp, generator Generator, args *GeneratorArgs) string
+
+// GeneratorArgs are arguments passed to NewGenerator that control how generators
+// are created.
+type GeneratorArgs struct {
+	// May be nil.
+	// Used to seed a custom RNG that is a lot faster than the default implementation.
+	// See http://vigna.di.unimi.it/ftp/papers/xorshift.pdf.
+	RngSource rand.Source
+
+	// Default is 0 (syntax.POSIX).
+	Flags syntax.Flags
+
+	// Maximum number of instances to generate for unbounded repeat expressions (e.g. ".*" and "{1,}")
+	// Default is DefaultMaxUnboundedRepeatCount.
+	MaxUnboundedRepeatCount uint
+	// Minimum number of instances to generate for unbounded repeat expressions (e.g. ".*")
+	// Default is 0.
+	MinUnboundedRepeatCount uint
+
+	// Set this to perform special processing of capture groups (e.g. `(\w+)`). The zero value will generate strings
+	// from the expressions in the group.
+	CaptureGroupHandler CaptureGroupHandler
+
+	// Used by generators.
+	rng *rand.Rand
+}
+
+func (a *GeneratorArgs) initialize() error {
+	var seed int64
+	if nil == a.RngSource {
+		seed = rand.Int63()
+	} else {
+		seed = a.RngSource.Int63()
+	}
+	rngSource := xorShift64Source(seed)
+	a.rng = rand.New(&rngSource)
+
+	// unicode groups only allowed with Perl
+	if (a.Flags&syntax.UnicodeGroups) == syntax.UnicodeGroups && (a.Flags&syntax.Perl) != syntax.Perl {
+		return generatorError(nil, "UnicodeGroups not supported")
+	}
+
+	if a.MaxUnboundedRepeatCount < 1 {
+		a.MaxUnboundedRepeatCount = DefaultMaxUnboundedRepeatCount
+	}
+
+	if a.MinUnboundedRepeatCount > a.MaxUnboundedRepeatCount {
+		panic(fmt.Sprintf("MinUnboundedRepeatCount(%d) > MaxUnboundedRepeatCount(%d)",
+			a.MinUnboundedRepeatCount, a.MaxUnboundedRepeatCount))
+	}
+
+	if a.CaptureGroupHandler == nil {
+		a.CaptureGroupHandler = defaultCaptureGroupHandler
+	}
+
+	return nil
+}
+
+// Rng returns the random number generator used by generators.
+// Panics if called before the GeneratorArgs has been initialized by NewGenerator.
+func (a *GeneratorArgs) Rng() *rand.Rand {
+	if a.rng == nil {
+		panic("GeneratorArgs has not been initialized by NewGenerator yet")
+	}
+	return a.rng
+}
+
+// Generator generates random strings.
+type Generator interface {
+	Generate() string
+	String() string
+}
+
+/*
+Generate a random string that matches the regular expression pattern.
+If args is nil, default values are used.
+
+This function does not seed the default RNG, so you must call rand.Seed() if you want
+non-deterministic strings.
+*/
+func Generate(pattern string) (string, error) {
+	generator, err := NewGenerator(pattern, nil)
+	if err != nil {
+		return "", err
+	}
+	return generator.Generate(), nil
+}
+
+// NewGenerator creates a generator that returns random strings that match the regular expression in pattern.
+// If args is nil, default values are used.
+func NewGenerator(pattern string, inputArgs *GeneratorArgs) (generator Generator, err error) {
+	args := GeneratorArgs{}
+
+	// Copy inputArgs so the caller can't change them.
+	if inputArgs != nil {
+		args = *inputArgs
+	}
+	if err = args.initialize(); err != nil {
+		return nil, err
+	}
+
+	var regexp *syntax.Regexp
+	regexp, err = syntax.Parse(pattern, args.Flags)
+	if err != nil {
+		return
+	}
+
+	var gen *internalGenerator
+	gen, err = newGenerator(regexp, &args)
+	if err != nil {
+		return
+	}
+
+	return gen, nil
+}

--- a/vendor/github.com/zach-klippenstein/goregen/regen_benchmarks_test.go
+++ b/vendor/github.com/zach-klippenstein/goregen/regen_benchmarks_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"math/rand"
+	"testing"
+)
+
+const BigFancyRegexp = `
+POST (/[-a-zA-Z0-9_.]{3,12}){3,6}
+Content-Length: [0-9]{2,3}
+X-Auth-Token: [a-zA-Z0-9+/]{64}
+
+([A-Za-z0-9+/]{64}
+){3,15}[A-Za-z0-9+/]{60}([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)
+`
+
+var rngSource = rand.NewSource(42)
+
+// Benchmarks the code that creates generators.
+// Doesn't actually run the generators.
+func BenchmarkComplexCreation(b *testing.B) {
+	// Create everything here to save allocations in the loop.
+	//args := &GeneratorArgs{rngSource, 0, NewSerialExecutor()}
+	args := &GeneratorArgs{
+		RngSource: rngSource,
+		Flags:     0,
+	}
+
+	for i := 0; i < b.N; i++ {
+		NewGenerator(BigFancyRegexp, args)
+	}
+}
+
+func BenchmarkLargeRepeatCreateSerial(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewGenerator(`a{999}`, &GeneratorArgs{
+			RngSource: rand.NewSource(0),
+		})
+	}
+}
+
+func BenchmarkComplexGeneration(b *testing.B) {
+	args := &GeneratorArgs{
+		RngSource: rngSource,
+	}
+	generator, err := NewGenerator(BigFancyRegexp, args)
+	if err != nil {
+		panic(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		generator.Generate()
+	}
+}
+
+func BenchmarkLargeRepeatGenerateSerial(b *testing.B) {
+	generator, err := NewGenerator(`a{999}`, &GeneratorArgs{
+		RngSource: rand.NewSource(0),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		generator.Generate()
+	}
+}

--- a/vendor/github.com/zach-klippenstein/goregen/regen_test.go
+++ b/vendor/github.com/zach-klippenstein/goregen/regen_test.go
@@ -1,0 +1,615 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"regexp"
+	"regexp/syntax"
+	"testing"
+
+	"github.com/google/gxui/math"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// Each expression is generated and validated this many times.
+	SampleSize = 999
+
+	// Arbitrary limit in the standard package.
+	// See https://golang.org/src/regexp/syntax/parse.go?s=18885:18935#L796
+	MaxSupportedRepeatCount = 1000
+)
+
+func ExampleGenerate() {
+	pattern := "[ab]{5}"
+	str, _ := Generate(pattern)
+
+	if matched, _ := regexp.MatchString(pattern, str); matched {
+		fmt.Println("Matches!")
+	}
+
+	// Output:
+	// Matches!
+}
+
+func ExampleNewGenerator() {
+	pattern := "[ab]{5}"
+
+	generator, _ := NewGenerator(pattern, &GeneratorArgs{
+		RngSource: rand.NewSource(0),
+	})
+
+	str := generator.Generate()
+
+	if matched, _ := regexp.MatchString(pattern, str); matched {
+		fmt.Println("Matches!")
+	}
+
+	// Output:
+	// Matches!
+}
+
+func ExampleNewGenerator_perl() {
+	pattern := `\d{5}`
+
+	generator, _ := NewGenerator(pattern, &GeneratorArgs{
+		Flags: syntax.Perl,
+	})
+
+	str := generator.Generate()
+
+	if matched, _ := regexp.MatchString("[[:digit:]]{5}", str); matched {
+		fmt.Println("Matches!")
+	}
+	// Output:
+	// Matches!
+}
+
+func ExampleCaptureGroupHandler() {
+	pattern := `Hello, (?P<firstname>[A-Z][a-z]{2,10}) (?P<lastname>[A-Z][a-z]{2,10})`
+
+	generator, _ := NewGenerator(pattern, &GeneratorArgs{
+		Flags: syntax.Perl,
+		CaptureGroupHandler: func(index int, name string, group *syntax.Regexp, generator Generator, args *GeneratorArgs) string {
+			if name == "firstname" {
+				return fmt.Sprintf("FirstName (e.g. %s)", generator.Generate())
+			}
+			return fmt.Sprintf("LastName (e.g. %s)", generator.Generate())
+		},
+	})
+
+	// Print to stderr since we're generating random output and can't assert equality.
+	fmt.Fprintln(os.Stderr, generator.Generate())
+
+	// Needed for "go test" to run this example. (Must be a blank line before.)
+
+	// Output:
+}
+
+func TestGeneratorArgs(t *testing.T) {
+	t.Parallel()
+
+	Convey("initialize", t, func() {
+		Convey("Handles empty struct", func() {
+			args := GeneratorArgs{}
+
+			var err error
+			So(func() { err = args.initialize() }, ShouldNotPanic)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Unicode groups not supported", func() {
+			args := &GeneratorArgs{
+				Flags: syntax.UnicodeGroups,
+			}
+
+			err := args.initialize()
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "UnicodeGroups not supported")
+		})
+
+		Convey("Panics if repeat bounds are invalid", func() {
+			args := &GeneratorArgs{
+				MinUnboundedRepeatCount: 2,
+				MaxUnboundedRepeatCount: 1,
+			}
+
+			So(func() { args.initialize() },
+				ShouldPanicWith,
+				"MinUnboundedRepeatCount(2) > MaxUnboundedRepeatCount(1)")
+		})
+
+		Convey("Allows equal repeat bounds", func() {
+			args := &GeneratorArgs{
+				MinUnboundedRepeatCount: 1,
+				MaxUnboundedRepeatCount: 1,
+			}
+
+			var err error
+			So(func() { err = args.initialize() }, ShouldNotPanic)
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("Rng", t, func() {
+		Convey("Panics if called before initialization", func() {
+			args := GeneratorArgs{}
+			So(func() { args.Rng() }, ShouldPanic)
+		})
+
+		Convey("Non-nil after initialization", func() {
+			args := GeneratorArgs{}
+			err := args.initialize()
+			So(err, ShouldBeNil)
+			So(args.Rng(), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestNewGenerator(t *testing.T) {
+	t.Parallel()
+
+	Convey("NewGenerator", t, func() {
+
+		Convey("Handles nil GeneratorArgs", func() {
+			generator, err := NewGenerator("", nil)
+			So(generator, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Handles empty GeneratorArgs", func() {
+			generator, err := NewGenerator("", &GeneratorArgs{})
+			So(generator, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Forwards errors from args initialization", func() {
+			args := &GeneratorArgs{
+				Flags: syntax.UnicodeGroups,
+			}
+
+			_, err := NewGenerator("", args)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestGenEmpty(t *testing.T) {
+	t.Parallel()
+
+	Convey("Empty", t, func() {
+		args := &GeneratorArgs{
+			RngSource: rand.NewSource(0),
+		}
+		ConveyGeneratesStringMatching(args, "", "^$")
+	})
+}
+
+func TestGenLiterals(t *testing.T) {
+	t.Parallel()
+
+	Convey("Literals", t, func() {
+		ConveyGeneratesStringMatchingItself(nil,
+			"a",
+			"abc",
+		)
+	})
+}
+
+func TestGenDotNotNl(t *testing.T) {
+	t.Parallel()
+
+	Convey("DotNotNl", t, func() {
+		ConveyGeneratesStringMatchingItself(nil, ".")
+
+		Convey("No newlines are generated", func() {
+			generator, _ := NewGenerator(".", nil)
+
+			// Not a very strong assertion, but not sure how to do better. Exploring the entire
+			// generation space (2^32) takes far too long for a unit test.
+			for i := 0; i < SampleSize; i++ {
+				So(generator.Generate(), ShouldNotContainSubstring, "\n")
+			}
+		})
+	})
+}
+
+func TestGenStringStartEnd(t *testing.T) {
+	t.Parallel()
+
+	Convey("String start/end", t, func() {
+		args := &GeneratorArgs{
+			RngSource: rand.NewSource(0),
+			Flags:     0,
+		}
+
+		ConveyGeneratesStringMatching(args, `^abc$`, `^abc$`)
+		ConveyGeneratesStringMatching(args, `$abc^`, `^abc$`)
+		ConveyGeneratesStringMatching(args, `a^b$c`, `^abc$`)
+	})
+}
+
+func TestGenQuestionMark(t *testing.T) {
+	t.Parallel()
+
+	Convey("QuestionMark", t, func() {
+		ConveyGeneratesStringMatchingItself(nil,
+			"a?",
+			"(abc)?",
+			"[ab]?",
+			".?")
+	})
+}
+
+func TestGenPlus(t *testing.T) {
+	t.Parallel()
+
+	Convey("Plus", t, func() {
+		ConveyGeneratesStringMatchingItself(nil, "a+")
+	})
+}
+
+func TestGenStar(t *testing.T) {
+	t.Parallel()
+
+	Convey("Star", t, func() {
+		ConveyGeneratesStringMatchingItself(nil, "a*")
+
+		Convey("HitsDefaultMin", func() {
+			regexp := "a*"
+			args := &GeneratorArgs{
+				RngSource: rand.NewSource(0),
+			}
+			counts := generateLenHistogram(regexp, DefaultMaxUnboundedRepeatCount, args)
+
+			So(counts[0], ShouldBeGreaterThan, 0)
+		})
+
+		Convey("HitsCustomMin", func() {
+			regexp := "a*"
+			args := &GeneratorArgs{
+				RngSource:               rand.NewSource(0),
+				MinUnboundedRepeatCount: 200,
+			}
+			counts := generateLenHistogram(regexp, DefaultMaxUnboundedRepeatCount, args)
+
+			So(counts[200], ShouldBeGreaterThan, 0)
+			for i := 0; i < 200; i++ {
+				So(counts[i], ShouldEqual, 0)
+			}
+		})
+
+		Convey("HitsDefaultMax", func() {
+			regexp := "a*"
+			args := &GeneratorArgs{
+				RngSource: rand.NewSource(0),
+			}
+			counts := generateLenHistogram(regexp, DefaultMaxUnboundedRepeatCount, args)
+
+			So(len(counts), ShouldEqual, DefaultMaxUnboundedRepeatCount+1)
+			So(counts[DefaultMaxUnboundedRepeatCount], ShouldBeGreaterThan, 0)
+		})
+
+		Convey("HitsCustomMax", func() {
+			regexp := "a*"
+			args := &GeneratorArgs{
+				RngSource:               rand.NewSource(0),
+				MaxUnboundedRepeatCount: 200,
+			}
+			counts := generateLenHistogram(regexp, 200, args)
+
+			So(len(counts), ShouldEqual, 200+1)
+			So(counts[200], ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+func TestGenCharClassNotNl(t *testing.T) {
+	t.Parallel()
+
+	Convey("CharClassNotNl", t, func() {
+		ConveyGeneratesStringMatchingItself(nil,
+			"[a]",
+			"[abc]",
+			"[a-d]",
+			"[ac]",
+			"[0-9]",
+			"[a-z0-9]",
+		)
+
+		Convey("No newlines are generated", func() {
+			// Try to narrow down the generation space. Still not a very strong assertion.
+			generator, _ := NewGenerator("[^a-zA-Z0-9]", nil)
+			for i := 0; i < SampleSize; i++ {
+				assert.NotEqual(t, "\n", generator.Generate())
+			}
+		})
+	})
+}
+
+func TestGenNegativeCharClass(t *testing.T) {
+	t.Parallel()
+
+	Convey("NegativeCharClass", t, func() {
+		ConveyGeneratesStringMatchingItself(nil, "[^a-zA-Z0-9]")
+	})
+}
+
+func TestGenAlternate(t *testing.T) {
+	t.Parallel()
+
+	Convey("Alternate", t, func() {
+		ConveyGeneratesStringMatchingItself(nil,
+			"a|b",
+			"abc|def|ghi",
+			"[ab]|[cd]",
+			"foo|bar|baz", // rewrites to foo|ba[rz]
+		)
+	})
+}
+
+func TestGenCapture(t *testing.T) {
+	t.Parallel()
+
+	Convey("Capture", t, func() {
+		ConveyGeneratesStringMatching(nil, "(abc)", "^abc$")
+		ConveyGeneratesStringMatching(nil, "()", "^$")
+	})
+}
+
+func TestGenConcat(t *testing.T) {
+	t.Parallel()
+
+	Convey("Concat", t, func() {
+		ConveyGeneratesStringMatchingItself(nil, "[ab][cd]")
+	})
+}
+
+func TestGenRepeat(t *testing.T) {
+	t.Parallel()
+
+	Convey("Repeat", t, func() {
+
+		Convey("Unbounded", func() {
+			ConveyGeneratesStringMatchingItself(nil, `a{1,}`)
+
+			Convey("HitsDefaultMax", func() {
+				regexp := "a{0,}"
+				args := &GeneratorArgs{
+					RngSource: rand.NewSource(0),
+				}
+				counts := generateLenHistogram(regexp, DefaultMaxUnboundedRepeatCount, args)
+
+				So(len(counts), ShouldEqual, DefaultMaxUnboundedRepeatCount+1)
+				So(counts[DefaultMaxUnboundedRepeatCount], ShouldBeGreaterThan, 0)
+			})
+
+			Convey("HitsCustomMax", func() {
+				regexp := "a{0,}"
+				args := &GeneratorArgs{
+					RngSource:               rand.NewSource(0),
+					MaxUnboundedRepeatCount: 200,
+				}
+				counts := generateLenHistogram(regexp, 200, args)
+
+				So(len(counts), ShouldEqual, 200+1)
+				So(counts[200], ShouldBeGreaterThan, 0)
+			})
+		})
+
+		Convey("HitsMin", func() {
+			regexp := "a{0,3}"
+			args := &GeneratorArgs{
+				RngSource: rand.NewSource(0),
+			}
+			counts := generateLenHistogram(regexp, 3, args)
+
+			So(len(counts), ShouldEqual, 3+1)
+			So(counts[0], ShouldBeGreaterThan, 0)
+		})
+
+		Convey("HitsMax", func() {
+			regexp := "a{0,3}"
+			args := &GeneratorArgs{
+				RngSource: rand.NewSource(0),
+			}
+			counts := generateLenHistogram(regexp, 3, args)
+
+			So(len(counts), ShouldEqual, 3+1)
+			So(counts[3], ShouldBeGreaterThan, 0)
+		})
+
+		Convey("IsWithinBounds", func() {
+			regexp := "a{5,10}"
+			args := &GeneratorArgs{
+				RngSource: rand.NewSource(0),
+			}
+			counts := generateLenHistogram(regexp, 10, args)
+
+			So(len(counts), ShouldEqual, 11)
+
+			for i := 0; i < 11; i++ {
+				if i < 5 {
+					So(counts[i], ShouldEqual, 0)
+				} else if i < 11 {
+					So(counts[i], ShouldBeGreaterThan, 0)
+				}
+			}
+		})
+	})
+}
+
+func TestGenCharClasses(t *testing.T) {
+	t.Parallel()
+
+	Convey("CharClasses", t, func() {
+
+		Convey("Ascii", func() {
+			ConveyGeneratesStringMatchingItself(nil,
+				"[[:alnum:]]",
+				"[[:alpha:]]",
+				"[[:ascii:]]",
+				"[[:blank:]]",
+				"[[:cntrl:]]",
+				"[[:digit:]]",
+				"[[:graph:]]",
+				"[[:lower:]]",
+				"[[:print:]]",
+				"[[:punct:]]",
+				"[[:space:]]",
+				"[[:upper:]]",
+				"[[:word:]]",
+				"[[:xdigit:]]",
+				"[[:^alnum:]]",
+				"[[:^alpha:]]",
+				"[[:^ascii:]]",
+				"[[:^blank:]]",
+				"[[:^cntrl:]]",
+				"[[:^digit:]]",
+				"[[:^graph:]]",
+				"[[:^lower:]]",
+				"[[:^print:]]",
+				"[[:^punct:]]",
+				"[[:^space:]]",
+				"[[:^upper:]]",
+				"[[:^word:]]",
+				"[[:^xdigit:]]",
+			)
+		})
+
+		Convey("Perl", func() {
+			args := &GeneratorArgs{
+				Flags: syntax.Perl,
+			}
+
+			ConveyGeneratesStringMatchingItself(args,
+				`\d`,
+				`\s`,
+				`\w`,
+				`\D`,
+				`\S`,
+				`\W`,
+			)
+		})
+	})
+}
+
+func TestCaptureGroupHandler(t *testing.T) {
+	t.Parallel()
+
+	Convey("CaptureGroupHandler", t, func() {
+		callCount := 0
+
+		gen, err := NewGenerator(`(?:foo) (bar) (?P<name>baz)`, &GeneratorArgs{
+			Flags: syntax.PerlX,
+			CaptureGroupHandler: func(index int, name string, group *syntax.Regexp, generator Generator, args *GeneratorArgs) string {
+				callCount++
+
+				So(index, ShouldBeLessThan, 2)
+
+				if index == 0 {
+					So(name, ShouldEqual, "")
+					So(group.String(), ShouldEqual, "bar")
+					So(generator.Generate(), ShouldEqual, "bar")
+					return "one"
+				}
+
+				// Index 1
+				So(name, ShouldEqual, "name")
+				So(group.String(), ShouldEqual, "baz")
+				So(generator.Generate(), ShouldEqual, "baz")
+				return "two"
+			},
+		})
+		So(err, ShouldBeNil)
+
+		So(gen.Generate(), ShouldEqual, "foo one two")
+		So(callCount, ShouldEqual, 2)
+	})
+}
+
+func ConveyGeneratesStringMatchingItself(args *GeneratorArgs, patterns ...string) {
+	for _, pattern := range patterns {
+		Convey(fmt.Sprintf("String generated from /%s/ matches itself", pattern), func() {
+			So(pattern, ShouldGenerateStringMatching, pattern, args)
+		})
+	}
+}
+
+func ConveyGeneratesStringMatching(args *GeneratorArgs, pattern string, expectedPattern string) {
+	Convey(fmt.Sprintf("String generated from /%s/ matches /%s/", pattern, expectedPattern), func() {
+		So(pattern, ShouldGenerateStringMatching, expectedPattern, args)
+	})
+}
+
+func ShouldGenerateStringMatching(actual interface{}, expected ...interface{}) string {
+	return ShouldGenerateStringMatchingTimes(actual, expected[0], expected[1], SampleSize)
+}
+
+func ShouldGenerateStringMatchingTimes(actual interface{}, expected ...interface{}) string {
+	pattern := actual.(string)
+	expectedPattern := expected[0].(string)
+	args := expected[1].(*GeneratorArgs)
+	times := expected[2].(int)
+
+	generator, err := NewGenerator(pattern, args)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < times; i++ {
+		result := generator.Generate()
+		matched, err := regexp.MatchString(expectedPattern, result)
+		if err != nil {
+			panic(err)
+		}
+		if !matched {
+			return fmt.Sprintf("string “%s” generated from /%s/ did not match /%s/.",
+				result, pattern, expectedPattern)
+		}
+	}
+
+	return ""
+}
+
+func generateLenHistogram(regexp string, maxLen int, args *GeneratorArgs) (counts []int) {
+	generator, err := NewGenerator(regexp, args)
+	if err != nil {
+		panic(err)
+	}
+
+	iterations := math.Max(maxLen*4, SampleSize)
+
+	for i := 0; i < iterations; i++ {
+		str := generator.Generate()
+
+		// Grow the slice if necessary.
+		if len(str) >= len(counts) {
+			newCounts := make([]int, len(str)+1)
+			copy(newCounts, counts)
+			counts = newCounts
+		}
+
+		counts[len(str)]++
+	}
+
+	return
+}

--- a/vendor/github.com/zach-klippenstein/goregen/regexp_format.go
+++ b/vendor/github.com/zach-klippenstein/goregen/regexp_format.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp/syntax"
+)
+
+// inspectRegexpToString returns a string describing a regular expression.
+func inspectRegexpToString(r *syntax.Regexp) string {
+	var buffer bytes.Buffer
+	inspectRegexpToWriter(&buffer, r)
+	return buffer.String()
+}
+
+// inspectPatternsToString returns a string describing one or more regular expressions.
+func inspectPatternsToString(simplify bool, patterns ...string) string {
+	var buffer bytes.Buffer
+	for _, pattern := range patterns {
+		inspectPatternsToWriter(simplify, &buffer, pattern)
+	}
+	return buffer.String()
+}
+func inspectPatternsToWriter(simplify bool, w io.Writer, patterns ...string) {
+	for _, pattern := range patterns {
+		inspectRegexpToWriter(w, parseOrPanic(simplify, pattern))
+	}
+}
+
+func inspectRegexpToWriter(w io.Writer, r ...*syntax.Regexp) {
+	for _, regexp := range r {
+		inspectWithIndent(regexp, "", w)
+	}
+}
+
+func inspectWithIndent(r *syntax.Regexp, indent string, w io.Writer) {
+	fmt.Fprintf(w, "%s{\n", indent)
+	fmt.Fprintf(w, "%s  Op: %s\n", indent, opToString(r.Op))
+	fmt.Fprintf(w, "%s  Flags: %x\n", indent, r.Flags)
+	if len(r.Sub) > 0 {
+		fmt.Fprintf(w, "%s  Sub: [\n", indent)
+		for _, subR := range r.Sub {
+			inspectWithIndent(subR, indent+"    ", w)
+		}
+		fmt.Fprintf(w, "%s  ]\n", indent)
+	} else {
+		fmt.Fprintf(w, "%s  Sub: []\n", indent)
+	}
+	fmt.Fprintf(w, "%s  Rune: %s (%s)\n", indent, runesToString(r.Rune...), runesToDecimalString(r.Rune))
+	fmt.Fprintf(w, "%s  [Min, Max]: [%d, %d]\n", indent, r.Min, r.Max)
+	fmt.Fprintf(w, "%s  Cap: %d\n", indent, r.Cap)
+	fmt.Fprintf(w, "%s  Name: %s\n", indent, r.Name)
+}
+
+// ParseOrPanic parses a regular expression into an AST.
+// Panics on error.
+func parseOrPanic(simplify bool, pattern string) *syntax.Regexp {
+	regexp, err := syntax.Parse(pattern, 0)
+	if err != nil {
+		panic(err)
+	}
+	if simplify {
+		regexp = regexp.Simplify()
+	}
+	return regexp
+}
+
+// runesToString converts a slice of runes to the string they represent.
+func runesToString(runes ...rune) string {
+	defer func() {
+		if err := recover(); err != nil {
+			panic(fmt.Errorf("RunesToString panicked"))
+		}
+	}()
+	var buffer bytes.Buffer
+	for _, r := range runes {
+		buffer.WriteRune(r)
+	}
+	return buffer.String()
+}
+
+// RunesToDecimalString converts a slice of runes to their comma-separated decimal values.
+func runesToDecimalString(runes []rune) string {
+	var buffer bytes.Buffer
+	for _, r := range runes {
+		buffer.WriteString(fmt.Sprintf("%d, ", r))
+	}
+	return buffer.String()
+}
+
+// opToString gets the string name of a regular expression operation.
+func opToString(op syntax.Op) string {
+	switch op {
+	case syntax.OpNoMatch:
+		return "OpNoMatch"
+	case syntax.OpEmptyMatch:
+		return "OpEmptyMatch"
+	case syntax.OpLiteral:
+		return "OpLiteral"
+	case syntax.OpCharClass:
+		return "OpCharClass"
+	case syntax.OpAnyCharNotNL:
+		return "OpAnyCharNotNL"
+	case syntax.OpAnyChar:
+		return "OpAnyChar"
+	case syntax.OpBeginLine:
+		return "OpBeginLine"
+	case syntax.OpEndLine:
+		return "OpEndLine"
+	case syntax.OpBeginText:
+		return "OpBeginText"
+	case syntax.OpEndText:
+		return "OpEndText"
+	case syntax.OpWordBoundary:
+		return "OpWordBoundary"
+	case syntax.OpNoWordBoundary:
+		return "OpNoWordBoundary"
+	case syntax.OpCapture:
+		return "OpCapture"
+	case syntax.OpStar:
+		return "OpStar"
+	case syntax.OpPlus:
+		return "OpPlus"
+	case syntax.OpQuest:
+		return "OpQuest"
+	case syntax.OpRepeat:
+		return "OpRepeat"
+	case syntax.OpConcat:
+		return "OpConcat"
+	case syntax.OpAlternate:
+		return "OpAlternate"
+	}
+
+	panic(fmt.Sprintf("invalid op: %d", op))
+}

--- a/vendor/github.com/zach-klippenstein/goregen/rng.go
+++ b/vendor/github.com/zach-klippenstein/goregen/rng.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+/*
+The default Source implementation is very slow to seed. Replaced with a
+64-bit xor-shift source from http://vigna.di.unimi.it/ftp/papers/xorshift.pdf.
+This source seeds very quickly, and only uses a single variable, so concurrent
+modification by multiple goroutines is possible.
+
+To create a seeded source:
+	randSource := xorShift64Source(mySeed)
+
+To create a source with the default seed:
+	var randSource xorShift64Source
+*/
+type xorShift64Source uint64
+
+func (src *xorShift64Source) Seed(seed int64) {
+	*src = xorShift64Source(seed)
+}
+
+func (src *xorShift64Source) Int63() int64 {
+	// A zero seed will only generate zeros.
+	if *src == 0 {
+		*src = 1
+	}
+
+	*src ^= *src >> 12 // a
+	*src ^= *src << 25 // b
+	*src ^= *src >> 27 // c
+
+	return int64((*src * 2685821657736338717) >> 1)
+}

--- a/vendor/github.com/zach-klippenstein/goregen/rng_test.go
+++ b/vendor/github.com/zach-klippenstein/goregen/rng_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2014 Zachary Klippenstein
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regen
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestXorShift64(t *testing.T) {
+	Convey("Int63 should never return negative numbers.", t, func() {
+		source := xorShift64Source(1)
+		for i := 0; i < SampleSize; i++ {
+			val := source.Int63()
+
+			So(val, ShouldBeGreaterThanOrEqualTo, 0)
+		}
+	})
+
+	Convey("Should not only return zeros", t, func() {
+		source := xorShift64Source(0)
+		nonZeroCount := 0
+
+		for i := 0; i < SampleSize; i++ {
+			if source.Int63() != 0 {
+				nonZeroCount++
+			}
+		}
+
+		So(nonZeroCount, ShouldBeGreaterThan, 0)
+	})
+}


### PR DESCRIPTION
Now, when you type "@memebot help" or an unrecognized keyword, instead of
"Try a regexp matching /show me (\w+)/", you get "Try something like “show me keyword”,
where "keyword" is a randomly-selected valid keyword.

If `ParseAllMessages=false` (`require-mention=true` on the command line), the sample message will
include the mention, otherwise it won't.
